### PR TITLE
Remove feature flags for standardized features (tail-call and multi-memory)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,14 +26,10 @@ default = []
 proposals = [
     "exception-handling",
     "extended-name-section",
-    "multi-memory",
-    "tail-call",
     "threads",
 ]
 exception-handling = []
 extended-name-section = []
-multi-memory = []
-tail-call = []
 threads = []
 nightly = []
 

--- a/README.md
+++ b/README.md
@@ -14,13 +14,11 @@ Following WebAssembly proposals are supported in addition to the core spec and c
 
 - [`exception-handling`](https://github.com/WebAssembly/exception-handling)
 - [`extended-name-section`](https://github.com/WebAssembly/extended-name-section)
-- [`multi-memory`](https://github.com/WebAssembly/multi-memory)
-- [`tail-call`](https://github.com/WebAssembly/tail-call)
 - [`threads`](https://github.com/WebAssembly/threads)
 
 ## Motivation
 
-Original blog post explaining motivation and internals: 
+Original blog post explaining motivation and internals:
 [wasmbin: a self-generating WebAssembly parser & serializer](https://rreverser.com/wasmbin-yet-another-webassembly-parser-serializer/).
 
 This crate intends to provide a low-level representation of the WebAssembly module that is fully described by Rust type system. It also leverages the said type system in conjunction with custom proc-macros to autogenerate parsing/serialization/visitation code for any complex types (structures and enums).

--- a/src/instructions/mod.rs
+++ b/src/instructions/mod.rs
@@ -116,47 +116,42 @@ impl crate::builtins::WasmbinCountable for Expression {}
 
 /// [Memory immediate argument](https://webassembly.github.io/spec/core/binary/instructions.html#memory-instructions).
 #[derive(Debug, PartialEq, Eq, Hash, Clone, Visit)]
-#[cfg_attr(not(feature = "multi-memory"), derive(Wasmbin))]
 pub struct MemArg {
     pub align_log2: u32,
-    #[cfg(feature = "multi-memory")]
     pub memory: MemId,
     pub offset: u32,
 }
 
-#[cfg(feature = "multi-memory")]
-const _: () = {
-    const MULTI_MEMORY_FLAG: u32 = 1 << 6;
+const MULTI_MEMORY_FLAG: u32 = 1 << 6;
 
-    impl Encode for MemArg {
-        fn encode(&self, w: &mut impl std::io::Write) -> std::io::Result<()> {
-            if self.memory.index != 0 {
-                (self.align_log2 | MULTI_MEMORY_FLAG).encode(w)?;
-                self.memory.encode(w)?;
-            } else {
-                self.align_log2.encode(w)?;
-            }
-            self.offset.encode(w)
+impl Encode for MemArg {
+    fn encode(&self, w: &mut impl std::io::Write) -> std::io::Result<()> {
+        if self.memory.index != 0 {
+            (self.align_log2 | MULTI_MEMORY_FLAG).encode(w)?;
+            self.memory.encode(w)?;
+        } else {
+            self.align_log2.encode(w)?;
         }
+        self.offset.encode(w)
     }
+}
 
-    impl Decode for MemArg {
-        fn decode(r: &mut impl std::io::Read) -> Result<Self, DecodeError> {
-            let mut align_log2 = u32::decode(r)?;
-            let memory = if align_log2 & MULTI_MEMORY_FLAG != 0 {
-                align_log2 &= !MULTI_MEMORY_FLAG;
-                MemId::decode(r)?
-            } else {
-                MemId::from(0)
-            };
-            Ok(Self {
-                align_log2,
-                memory,
-                offset: u32::decode(r)?,
-            })
-        }
+impl Decode for MemArg {
+    fn decode(r: &mut impl std::io::Read) -> Result<Self, DecodeError> {
+        let mut align_log2 = u32::decode(r)?;
+        let memory = if align_log2 & MULTI_MEMORY_FLAG != 0 {
+            align_log2 &= !MULTI_MEMORY_FLAG;
+            MemId::decode(r)?
+        } else {
+            MemId::from(0)
+        };
+        Ok(Self {
+            align_log2,
+            memory,
+            offset: u32::decode(r)?,
+        })
     }
-};
+}
 
 /// An [indirect call](https://webassembly.github.io/spec/core/binary/instructions.html#control-instructions).
 #[derive(Wasmbin, Debug, PartialEq, Eq, Hash, Clone, Visit)]
@@ -196,9 +191,7 @@ pub enum Instruction {
     Return = 0x0F,
     Call(FuncId) = 0x10,
     CallIndirect(CallIndirect) = 0x11,
-    #[cfg(feature = "tail-call")]
     ReturnCall(FuncId) = 0x12,
-    #[cfg(feature = "tail-call")]
     ReturnCallIndirect(CallIndirect) = 0x13,
     Drop = 0x1A,
     Select = 0x1B,

--- a/src/instructions/threads.rs
+++ b/src/instructions/threads.rs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 use super::MemArg;
-#[cfg(feature = "multi-memory")]
 use crate::instructions::MemId;
 use crate::io::{Decode, DecodeError, Encode, Wasmbin};
 use crate::visit::Visit;
@@ -21,7 +20,6 @@ use crate::visit::Visit;
 /// Variant of [`MemArg`] with a fixed compile-time alignment.
 #[derive(Debug, PartialEq, Eq, Hash, Clone, Visit)]
 pub struct AlignedMemArg<const ALIGN_LOG2: u32> {
-    #[cfg(feature = "multi-memory")]
     pub memory: MemId,
     pub offset: u32,
 }
@@ -30,7 +28,6 @@ impl<const ALIGN_LOG2: u32> From<AlignedMemArg<ALIGN_LOG2>> for MemArg {
     fn from(arg: AlignedMemArg<ALIGN_LOG2>) -> MemArg {
         MemArg {
             align_log2: ALIGN_LOG2,
-            #[cfg(feature = "multi-memory")]
             memory: arg.memory,
             offset: arg.offset,
         }
@@ -50,7 +47,6 @@ impl<const ALIGN_LOG2: u32> Decode for AlignedMemArg<ALIGN_LOG2> {
             return Err(DecodeError::unsupported_discriminant::<Self>(arg.offset));
         }
         Ok(Self {
-            #[cfg(feature = "multi-memory")]
             memory: arg.memory,
             offset: arg.offset,
         })

--- a/tests/spec.rs
+++ b/tests/spec.rs
@@ -151,8 +151,8 @@ impl Tests {
 
         read_proposal_tests!(? "exception-handling");
         read_proposal_tests!("extended-const");
-        read_proposal_tests!(? "multi-memory");
-        read_proposal_tests!(? "tail-call");
+        read_proposal_tests!("multi-memory");
+        read_proposal_tests!("tail-call");
         read_proposal_tests!(? "threads");
 
         ensure!(


### PR DESCRIPTION
These features are no longer in the proposal stages.

https://github.com/WebAssembly/proposals