### PR TITLE
Update formatting

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -15,6 +15,10 @@ jobs:
       uses: actions/checkout@v2
       with:
         submodules: true
+    - name: Install nightly toolchain
+      uses: dtolnay/rust-toolchain@nightly
+      with:
+        components: rustfmt, clippy
     - name: Check formatting
       run: cargo fmt --all -- --check
     - name: Run tests without proposals

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -15,6 +15,8 @@ jobs:
       uses: actions/checkout@v2
       with:
         submodules: true
+    - name: Check formatting
+      run: cargo fmt --all -- --check
     - name: Run tests without proposals
       run: cargo test -- -q
     - name: Run tests with proposals enabled

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -15,16 +15,20 @@ jobs:
       uses: actions/checkout@v2
       with:
         submodules: true
+    - name: Install stable toolchain
+      uses: dtolnay/rust-toolchain@stable
+      with:
+        components: clippy
     - name: Install nightly toolchain
       uses: dtolnay/rust-toolchain@nightly
       with:
-        components: rustfmt, clippy
+        components: rustfmt
     - name: Check formatting
-      run: cargo fmt --all -- --check
+      run: cargo +nightly fmt --all -- --check
     - name: Run tests without proposals
-      run: cargo test -- -q
+      run: cargo +stable test -- -q
     - name: Run tests with proposals enabled
-      run: cargo test --features=proposals -- -q
+      run: cargo +stable test --features=proposals -- -q
     - name: Run `clippy check`
       uses: giraffate/clippy-action@v1
       with:

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -12,13 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use criterion::{criterion_group, criterion_main, Criterion};
+use criterion::{Criterion, criterion_group, criterion_main};
 use std::fs::File;
 use std::hint::black_box;
 use tempfile::tempfile;
+use wasmbin::Module;
 use wasmbin::io::DecodeError;
 use wasmbin::visit::{Visit, VisitError};
-use wasmbin::Module;
 
 fn deep_module() -> Module {
     use wasmbin::builtins::Blob;
@@ -34,11 +34,13 @@ fn deep_module() -> Module {
         expr.push(Instruction::End);
     }
     Module {
-        sections: vec![vec![Blob::from(FuncBody {
-            locals: Default::default(),
-            expr,
-        })]
-        .into()],
+        sections: vec![
+            vec![Blob::from(FuncBody {
+                locals: Default::default(),
+                expr,
+            })]
+            .into(),
+        ],
     }
 }
 

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use quote::{quote, ToTokens};
+use quote::{ToTokens, quote};
 use std::borrow::Cow;
-use synstructure::{decl_derive, Structure, VariantInfo};
+use synstructure::{Structure, VariantInfo, decl_derive};
 
 macro_rules! syn_throw {
     ($err:expr) => {

--- a/examples/dump.rs
+++ b/examples/dump.rs
@@ -16,10 +16,10 @@ use anyhow::Context;
 use clap::{Parser, Subcommand};
 use std::fs::File;
 use std::io::{BufReader, Seek};
+use wasmbin::Module;
 use wasmbin::io::DecodeError;
 use wasmbin::sections::{Kind, Section};
 use wasmbin::visit::{Visit, VisitError};
-use wasmbin::Module;
 
 #[derive(Subcommand)]
 enum DumpSection {

--- a/src/builtins/boolean.rs
+++ b/src/builtins/boolean.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::io::{encode_decode_as, DecodeError};
+use crate::io::{DecodeError, encode_decode_as};
 use crate::visit::Visit;
 
 encode_decode_as!(bool, {

--- a/src/builtins/lazy.rs
+++ b/src/builtins/lazy.rs
@@ -206,9 +206,10 @@ impl<T: Decode + PartialEq> PartialEq for Lazy<T> {
     fn eq(&self, other: &Self) -> bool {
         if let (LazyStatus::FromInput { raw: raw1, .. }, LazyStatus::FromInput { raw: raw2, .. }) =
             (&self.status, &other.status)
-            && raw1 == raw2 {
-                return true;
-            }
+            && raw1 == raw2
+        {
+            return true;
+        }
         if let (Ok(value1), Ok(value2)) = (self.try_contents(), other.try_contents()) {
             return value1 == value2;
         }

--- a/src/instructions/exceptions.rs
+++ b/src/instructions/exceptions.rs
@@ -1,7 +1,7 @@
 use super::Instruction;
 use crate::builtins::WasmbinCountable;
 use crate::indices::{ExceptionId, LabelId};
-use crate::io::{encode_decode_as, Wasmbin};
+use crate::io::{Wasmbin, encode_decode_as};
 use crate::types::BlockType;
 use crate::visit::Visit;
 

--- a/src/instructions/mod.rs
+++ b/src/instructions/mod.rs
@@ -17,7 +17,7 @@
 use crate::builtins::FloatConst;
 use crate::indices::{DataId, ElemId, FuncId, GlobalId, LabelId, LocalId, MemId, TableId, TypeId};
 use crate::io::{
-    encode_decode_as, Decode, DecodeError, DecodeWithDiscriminant, Encode, PathItem, Wasmbin,
+    Decode, DecodeError, DecodeWithDiscriminant, Encode, PathItem, Wasmbin, encode_decode_as,
 };
 use crate::types::{BlockType, HeapType, ValueType};
 use crate::visit::Visit;

--- a/src/types.rs
+++ b/src/types.rs
@@ -17,7 +17,7 @@
 use crate::builtins::WasmbinCountable;
 use crate::indices::TypeId;
 use crate::io::{
-    encode_decode_as, Decode, DecodeError, DecodeWithDiscriminant, Encode, PathItem, Wasmbin,
+    Decode, DecodeError, DecodeWithDiscriminant, Encode, PathItem, Wasmbin, encode_decode_as,
 };
 use crate::visit::Visit;
 use std::convert::TryFrom;

--- a/tests/spec.rs
+++ b/tests/spec.rs
@@ -12,18 +12,18 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use anyhow::{bail, ensure, Result};
+use anyhow::{Result, bail, ensure};
 use fs_err::{read_dir, read_to_string};
 use indexmap::IndexMap;
-use libtest_mimic::{run as run_tests, Arguments, Failed, Trial};
+use libtest_mimic::{Arguments, Failed, Trial, run as run_tests};
 use rayon::prelude::*;
 use std::path::Path;
 use std::sync::Arc;
+use wasmbin::Module;
 use wasmbin::io::DecodeError;
 use wasmbin::visit::{Visit, VisitError};
-use wasmbin::Module;
 use wast::lexer::Lexer;
-use wast::parser::{parse, ParseBuffer};
+use wast::parser::{ParseBuffer, parse};
 use wast::{QuoteWat, Wast};
 
 const IGNORED_ERRORS: &[&str] = &[
@@ -198,8 +198,14 @@ fn unlazify<T: Visit>(mut wasm: T) -> Result<T, DecodeError> {
 
 fn run_test(mut test_module: &[u8], expect_result: Result<(), String>) -> Result<()> {
     let orig_test_module = test_module;
-    let module = match (Module::decode_from(&mut test_module).and_then(unlazify), &expect_result) {
-        (Ok(ref module), Err(err)) => bail!("Expected an invalid module definition with an error: {err}\nParsed part: {parsed_part:02X?}\nGot module: {module:#?}", parsed_part = &orig_test_module[..orig_test_module.len() - test_module.len()]),
+    let module = match (
+        Module::decode_from(&mut test_module).and_then(unlazify),
+        &expect_result,
+    ) {
+        (Ok(ref module), Err(err)) => bail!(
+            "Expected an invalid module definition with an error: {err}\nParsed part: {parsed_part:02X?}\nGot module: {module:#?}",
+            parsed_part = &orig_test_module[..orig_test_module.len() - test_module.len()]
+        ),
         (Err(err), Ok(())) => bail!(
             "Error: {err:#}\nExpected a valid module definition, but got an error\nModule: {orig_test_module:#02X?}"
         ),


### PR DESCRIPTION
Updates formatting using rustfmt 1.8.0-nightly.

In my last PR (https://github.com/RReverser/wasmbin/pull/8) I manually undid changes introduced by `cargo fmt`, assuming it was because I was on nightly (I should have re-run on stable, that was laziness on my part). In fact, the real reason was simply updates to rustfmt since the project was last formatted.

This pull request updates the project's formatting and adds formatting checks to the GitHub workflow.

However, the options used in the project's `rustfmt.toml` aren't stable and will be ignored in the workflow (becoming more lenient, rather than more strict, as the default behaviour is "preserve" when the options are ignored).

I think it would be a good idea to remove the unstable formatting options and format on rustfmt stable. If you'd prefer that, let me know and I'll update the pull request.

If you would prefer to keep the unstable rustfmt options, let me know whether I should also update the workflow to use nightly rustfmt.